### PR TITLE
C.cc: Aliases should only be freed if they exist.

### DIFF
--- a/client/c.cc
+++ b/client/c.cc
@@ -413,8 +413,8 @@ weaver_client_destroy_nodes(struct node *nodes,
                 for (size_t j = 0; j < nodes[i].aliases_sz; j++) {
                     weaver_client_destroy_handles(nodes[i].aliases[j], 1);
                 }
+                free(nodes[i].aliases);
             }
-            free(nodes[i].aliases);
         }
         free(nodes);
     }


### PR DESCRIPTION
Bugfix. Was probabilistically segfaulting.